### PR TITLE
Update dependency and plugin versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,21 +46,21 @@
     <jakarta.xml.bind-api.version>4.0.2</jakarta.xml.bind-api.version>
     <jetbrains-annotations.version>24.1.0</jetbrains-annotations.version>
     <junit.version>6.0.1</junit.version>
-    <logback.version>1.5.20</logback.version>
-    <milo.version>1.1.0</milo.version>
-    <netty.version>4.2.7.Final</netty.version>
-    <typesafe-config.version>1.4.5</typesafe-config.version>
+    <logback.version>1.5.32</logback.version>
+    <milo.version>1.1.1</milo.version>
+    <netty.version>4.2.10.Final</netty.version>
+    <typesafe-config.version>1.4.6</typesafe-config.version>
     <uanodeset.version>0.4.1</uanodeset.version>
 
     <!-- Plugin Dependencies -->
-    <buildnumber-maven-plugin.version>3.2.1</buildnumber-maven-plugin.version>
-    <maven-dependency-plugin.version>3.9.0</maven-dependency-plugin.version>
+    <buildnumber-maven-plugin.version>3.3.0</buildnumber-maven-plugin.version>
+    <maven-dependency-plugin.version>3.10.0</maven-dependency-plugin.version>
     <maven-enforcer-plugin.version>3.6.2</maven-enforcer-plugin.version>
-    <maven-failsafe-plugin.version>3.5.4</maven-failsafe-plugin.version>
-    <maven-shade-plugin.version>3.6.1</maven-shade-plugin.version>
-    <maven-surefire-plugin.version>3.5.4</maven-surefire-plugin.version>
-    <spotless-maven-plugin.version>3.0.0</spotless-maven-plugin.version>
-    <native-maven-plugin.version>0.11.1</native-maven-plugin.version>
+    <maven-failsafe-plugin.version>3.5.5</maven-failsafe-plugin.version>
+    <maven-shade-plugin.version>3.6.2</maven-shade-plugin.version>
+    <maven-surefire-plugin.version>3.5.5</maven-surefire-plugin.version>
+    <spotless-maven-plugin.version>3.3.0</spotless-maven-plugin.version>
+    <native-maven-plugin.version>0.11.5</native-maven-plugin.version>
   </properties>
 
   <build>


### PR DESCRIPTION
## Dependencies

- Logback 1.5.20 → 1.5.32
- Milo 1.1.0 → 1.1.1
- Netty 4.2.7.Final → 4.2.10.Final
- Typesafe Config 1.4.5 → 1.4.6

## Plugins

- buildnumber-maven-plugin 3.2.1 → 3.3.0
- maven-dependency-plugin 3.9.0 → 3.10.0
- maven-failsafe-plugin 3.5.4 → 3.5.5
- maven-shade-plugin 3.6.1 → 3.6.2
- maven-surefire-plugin 3.5.4 → 3.5.5
- spotless-maven-plugin 3.0.0 → 3.3.0
- native-maven-plugin 0.11.1 → 0.11.5