### PR TITLE
Omit incomplete DataTypeTest namespace metadata

### DIFF
--- a/src/main/java/com/digitalpetri/opcua/server/namespace/test/DataTypeTestNamespace.java
+++ b/src/main/java/com/digitalpetri/opcua/server/namespace/test/DataTypeTestNamespace.java
@@ -5,14 +5,21 @@ import com.digitalpetri.opcua.uanodeset.namespace.NodeSetNamespace;
 import java.io.InputStream;
 import java.util.List;
 import org.eclipse.milo.opcua.sdk.server.OpcUaServer;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaNode;
 import org.eclipse.milo.opcua.stack.core.encoding.EncodingContext;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 
 public class DataTypeTestNamespace extends NodeSetNamespace {
 
   public static final String NAMESPACE_URI = "https://github.com/digitalpetri/DataTypeTest";
+  private static final int NAMESPACE_METADATA_NODE_ID = 5010;
 
   public DataTypeTestNamespace(OpcUaServer server) {
     super(server, NAMESPACE_URI);
+
+    // OPC UA Part 5 permits omitting namespace metadata entries when mandatory
+    // NamespaceMetadataType properties cannot be populated from the namespace.
+    getLifecycleManager().addStartupTask(this::deleteNamespaceMetadataNode);
   }
 
   @Override
@@ -36,5 +43,11 @@ public class DataTypeTestNamespace extends NodeSetNamespace {
         .initialize(server.getNamespaceTable(), server.getStaticDataTypeManager());
 
     return namespace;
+  }
+
+  private void deleteNamespaceMetadataNode() {
+    NodeId nodeId = new NodeId(getNamespaceIndex(), NAMESPACE_METADATA_NODE_ID);
+
+    getNodeManager().getNode(nodeId).ifPresent(UaNode::delete);
   }
 }

--- a/src/test/java/com/digitalpetri/opcua/server/namespace/test/DataTypeTestNamespaceIT.java
+++ b/src/test/java/com/digitalpetri/opcua/server/namespace/test/DataTypeTestNamespaceIT.java
@@ -1,0 +1,112 @@
+package com.digitalpetri.opcua.server.namespace.test;
+
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.digitalpetri.opcua.server.OpcUaDemoServer;
+import com.digitalpetri.opcua.server.OpcUaTestClient;
+import com.digitalpetri.opcua.server.OpcUaTestServerBuilder;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
+import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UShort;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.BrowseDirection;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.BrowseResultMask;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.TimestampsToReturn;
+import org.eclipse.milo.opcua.stack.core.types.structured.BrowseDescription;
+import org.eclipse.milo.opcua.stack.core.types.structured.BrowseResult;
+import org.eclipse.milo.opcua.stack.core.types.structured.ReferenceDescription;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class DataTypeTestNamespaceIT {
+
+  private static final int NAMESPACE_METADATA_NODE_ID = 5010;
+  private static final int STATIC_NODE_ID_TYPES_NODE_ID = 6015;
+  private static final int STATIC_NUMERIC_NODE_ID_RANGE_NODE_ID = 6016;
+  private static final int STATIC_STRING_NODE_ID_PATTERN_NODE_ID = 6017;
+
+  private OpcUaDemoServer server;
+  private OpcUaClient client;
+
+  @BeforeEach
+  void setUp(@TempDir Path tempDir) throws Exception {
+    Map<String, Object> configMap = new HashMap<>();
+    configMap.put("address-space.data-type-test.enabled", true);
+    Config customConfig = ConfigFactory.parseMap(configMap);
+
+    server = OpcUaTestServerBuilder.builder().withDataDir(tempDir).withConfig(customConfig).build();
+    server.startup();
+
+    client = OpcUaTestClient.create(server.getServer());
+    client.connect();
+  }
+
+  @AfterEach
+  void tearDown() throws Exception {
+    if (client != null) {
+      client.disconnect();
+    }
+    if (server != null) {
+      server.shutdown();
+    }
+  }
+
+  @Test
+  void generatedNamespaceMetadataNodeIsNotExposed() throws Exception {
+    UShort namespaceIndex =
+        server.getServer().getNamespaceTable().getIndex(DataTypeTestNamespace.NAMESPACE_URI);
+    assertNotNull(namespaceIndex, "DataTypeTest namespace should be registered");
+
+    NodeId metadataNodeId = new NodeId(namespaceIndex, NAMESPACE_METADATA_NODE_ID);
+    assertTrue(
+        server.getServer().getAddressSpaceManager().getManagedNode(metadataNodeId).isEmpty(),
+        "generated NamespaceMetadataType node should not be exposed");
+    assertFalse(
+        serverNamespacesContains(DataTypeTestNamespace.NAMESPACE_URI),
+        "Server.Namespaces should not reference the generated NamespaceMetadataType node");
+
+    assertNodeIdUnknown(new NodeId(namespaceIndex, STATIC_NODE_ID_TYPES_NODE_ID));
+    assertNodeIdUnknown(new NodeId(namespaceIndex, STATIC_NUMERIC_NODE_ID_RANGE_NODE_ID));
+    assertNodeIdUnknown(new NodeId(namespaceIndex, STATIC_STRING_NODE_ID_PATTERN_NODE_ID));
+  }
+
+  private void assertNodeIdUnknown(NodeId nodeId) throws Exception {
+    DataValue dataValue = client.readValue(0.0, TimestampsToReturn.Neither, nodeId);
+
+    assertEquals(StatusCodes.Bad_NodeIdUnknown, dataValue.getStatusCode().getValue());
+  }
+
+  private boolean serverNamespacesContains(String browseName) throws Exception {
+    BrowseDescription browseDescription =
+        new BrowseDescription(
+            NodeIds.Server_Namespaces,
+            BrowseDirection.Forward,
+            null,
+            true,
+            uint(NodeClass.Object.getValue()),
+            uint(BrowseResultMask.All.getValue()));
+
+    BrowseResult browseResult = client.browse(browseDescription);
+    ReferenceDescription[] references = browseResult.getReferences();
+
+    return references != null
+        && Arrays.stream(references)
+            .anyMatch(ref -> Objects.equals(ref.getBrowseName().getName(), browseName));
+  }
+}


### PR DESCRIPTION
## Summary

- Stop exposing the generated DataTypeTest `NamespaceMetadataType` object at runtime because the generated NodeSet does not provide values for mandatory metadata properties.
- Leave `src/main/resources/DataTypeTest.NodeSet.xml` untouched; it is modeling-tool output and the PR diff is Java-only.
- Add an integration test that verifies the metadata object is absent from `Server.Namespaces` and the old metadata child NodeIds no longer return `BadNoValue`.

## RCA

CTT `Base Information / Base Info Core Structure 2 / 001.js` browses `Server.Namespaces` and reads the mandatory properties of any `NamespaceMetadataType` objects it finds. The DataTypeTest NodeSet includes a metadata object whose generated `StaticNumericNodeIdRange` and `StaticStringNodeIdPattern` children have no initial values, so reads could surface `BadNoValue` for nodes such as `ns=3;i=6016` and `ns=3;i=6017`.

OPC UA Part 5 makes those static metadata properties mandatory when a `NamespaceMetadataType` object exists, but `NamespacesType` also says clients should not assume every namespace used by a server is present under `Server.Namespaces`, since a namespace may not provide enough information to fill all mandatory metadata properties. Because this generated namespace cannot truthfully populate the metadata, omitting the metadata object is the spec-aligned behavior.

## Changes

- `DataTypeTestNamespace` registers a post-NodeSet-load startup task that deletes NodeId `5010`, the generated DataTypeTest namespace metadata object. Milo's `UaNode.delete()` recursively removes child nodes and references, so the incomplete metadata properties are no longer exposed.
- `DataTypeTestNamespaceIT` starts an embedded server with the DataTypeTest namespace enabled and verifies:
  - the DataTypeTest namespace is still registered,
  - the generated metadata object is not managed,
  - `Server.Namespaces` does not browse to that metadata entry,
  - the prior metadata child NodeIds now read as `Bad_NodeIdUnknown` instead of `BadNoValue`.

## Verification

- `mise exec -- mvn -q test -Dtest=DataTypeTestNamespaceIT` - passed.
- `mise exec -- mvn -q clean verify` - passed.
- Live focused CTT was not rerun from this worker because the demo-server endpoint and CTT project are shared resources; the orchestrator will serialize live CTT on the train branch.

## Spec References

- OPC UA Part 5, 6.3.13 `NamespaceMetadataType`: metadata properties are mandatory when the metadata object exists.
- OPC UA Part 5, 6.3.14 `NamespacesType`: clients should not assume all server namespaces are listed; a namespace may not provide information necessary to fill all mandatory `NamespaceMetadataType` properties.
