### PR TITLE
Fix Debug object browse type definition

### DIFF
--- a/src/main/java/com/digitalpetri/opcua/server/namespace/demo/debug/DebugNodesFragment.java
+++ b/src/main/java/com/digitalpetri/opcua/server/namespace/demo/debug/DebugNodesFragment.java
@@ -16,6 +16,7 @@ import org.eclipse.milo.opcua.sdk.server.items.DataItem;
 import org.eclipse.milo.opcua.sdk.server.items.MonitoredItem;
 import org.eclipse.milo.opcua.sdk.server.nodes.UaMethodNode;
 import org.eclipse.milo.opcua.sdk.server.nodes.UaObjectNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaObjectNode.UaObjectNodeBuilder;
 import org.eclipse.milo.opcua.sdk.server.util.SubscriptionModel;
 import org.eclipse.milo.opcua.stack.core.NodeIds;
 import org.eclipse.milo.opcua.stack.core.ReferenceTypes;
@@ -70,16 +71,14 @@ public class DebugNodesFragment extends ManagedAddressSpaceFragmentWithLifecycle
   }
 
   private void addDebugNodes() {
-    UaObjectNode debugNode =
-        new UaObjectNode(
-            getNodeContext(),
-            new NodeId(namespace.getNamespaceIndex(), "Debug"),
-            new QualifiedName(namespace.getNamespaceIndex(), "Debug"),
-            LocalizedText.english("Debug"),
-            LocalizedText.NULL_VALUE,
-            uint(0),
-            uint(0),
-            ubyte(0));
+    var builder = new UaObjectNodeBuilder(getNodeContext());
+    builder
+        .setNodeId(new NodeId(namespace.getNamespaceIndex(), "Debug"))
+        .setBrowseName(new QualifiedName(namespace.getNamespaceIndex(), "Debug"))
+        .setDisplayName(LocalizedText.english("Debug"))
+        .setEventNotifier(ubyte(0));
+
+    UaObjectNode debugNode = builder.build();
 
     getNodeManager().addNode(debugNode);
 

--- a/src/test/java/com/digitalpetri/opcua/server/namespace/demo/ctt/CttNodesIT.java
+++ b/src/test/java/com/digitalpetri/opcua/server/namespace/demo/ctt/CttNodesIT.java
@@ -16,6 +16,7 @@ import java.util.Objects;
 import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
 import org.eclipse.milo.opcua.stack.core.NodeIds;
 import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.BrowseDirection;
@@ -374,6 +375,43 @@ class CttNodesIT {
     assertNotNull(value, "Value should be readable");
     assertNotNull(value.getValue(), "Value should not be null");
     logger.info("Read AccessLevel_CurrentRead value: {}", value.getValue().getValue());
+  }
+
+  @Test
+  void testObjectReferencesFromObjectsFolderHaveTypeDefinitions() throws Exception {
+    BrowseDescription browseDescription =
+        new BrowseDescription(
+            NodeIds.ObjectsFolder,
+            BrowseDirection.Forward,
+            null,
+            true,
+            uint(NodeClass.Object.getValue()),
+            uint(BrowseResultMask.All.getValue()));
+
+    BrowseResult browseResult = client.browse(browseDescription);
+    assertTrue(
+        browseResult.getStatusCode().isGood(),
+        () -> "Browse ObjectsFolder failed: " + browseResult.getStatusCode());
+
+    ReferenceDescription[] references = browseResult.getReferences();
+    assertNotNull(references, "ObjectsFolder references should not be null");
+    assertTrue(references.length > 0, "ObjectsFolder should have Object references");
+
+    boolean foundDebugObject = false;
+    for (ReferenceDescription reference : references) {
+      if (Objects.equals(reference.getBrowseName().getName(), "Debug")) {
+        foundDebugObject = true;
+      }
+
+      ExpandedNodeId typeDefinition = reference.getTypeDefinition();
+      assertNotNull(
+          typeDefinition, () -> reference.getBrowseName() + " should include a TypeDefinition");
+      assertTrue(
+          typeDefinition.isNotNull(),
+          () -> reference.getBrowseName() + " should include a non-null TypeDefinition");
+    }
+
+    assertTrue(foundDebugObject, "Debug object should be present under ObjectsFolder");
   }
 
   /**


### PR DESCRIPTION
## Summary

Fix the demo server's Debug object so Browse returns a non-null TypeDefinition for Object references under ObjectsFolder, matching the View Basic 2 CTT expectation.

- Build the Debug object through Milo's object builder so it receives the required `HasTypeDefinition -> BaseObjectType` reference.
- Add a regression test that browses Object references from ObjectsFolder and verifies every returned Object reference has a non-null TypeDefinition, including Debug.

## Key Changes

- **Debug object construction:** The Debug node now uses `UaObjectNodeBuilder` instead of the raw `UaObjectNode` constructor, preserving its Object semantics while attaching the required type-definition reference.
- **Browse regression:** `CttNodesIT` now covers the CTT failure mode with an in-process server, checking the ReferenceDescription fields returned for ObjectsFolder Object references.

## Testing

- `mise exec -- mvn -q -Dtest=CttNodesIT#testObjectReferencesFromObjectsFolderHaveTypeDefinitions test`
- `mise exec -- mvn -q spotless:apply`
- `mise exec -- mvn -q -Dtest=CttNodesIT test`
- Focused CTT selection for `View Basic 2::018.js` was generated for the orchestrator-managed run; live CTT was not run here because the shared endpoint requires orchestration locking.
