### PR TITLE
Fix CTT ArrayItem engineering units

### DIFF
--- a/src/main/java/com/digitalpetri/opcua/server/namespace/demo/ctt/DataAccessProfileFragment.java
+++ b/src/main/java/com/digitalpetri/opcua/server/namespace/demo/ctt/DataAccessProfileFragment.java
@@ -7,6 +7,7 @@ import com.digitalpetri.opcua.server.namespace.demo.EuRangeCheckFilter;
 import com.digitalpetri.opcua.server.namespace.demo.Util;
 import java.util.List;
 import org.eclipse.milo.opcua.sdk.core.AccessLevel;
+import org.eclipse.milo.opcua.sdk.core.CefactEngineeringUnits;
 import org.eclipse.milo.opcua.sdk.core.Reference;
 import org.eclipse.milo.opcua.sdk.core.Reference.Direction;
 import org.eclipse.milo.opcua.sdk.core.ValueRanks;
@@ -49,6 +50,9 @@ import org.eclipse.milo.opcua.stack.core.types.structured.EnumValueType;
 import org.eclipse.milo.opcua.stack.core.types.structured.Range;
 
 public class DataAccessProfileFragment extends ManagedAddressSpaceFragmentWithLifecycle {
+
+  private static final EUInformation DIMENSIONLESS_UNITS = CefactEngineeringUnits.CODE_C62;
+  private static final EUInformation MILLIMETRE_UNITS = CefactEngineeringUnits.CODE_MMT;
 
   private final SimpleAddressSpaceFilter filter;
   private final SubscriptionModel subscriptionModel;
@@ -302,29 +306,28 @@ public class DataAccessProfileFragment extends ManagedAddressSpaceFragmentWithLi
         // Set ArrayItemType properties
         cubeItem.setInstrumentRange(new Range(0.0, 100.0));
         cubeItem.setEuRange(new Range(0.0, 100.0));
-        cubeItem.setEngineeringUnits(
-            new EUInformation("", -1, new LocalizedText(""), new LocalizedText("units")));
+        cubeItem.setEngineeringUnits(DIMENSIONLESS_UNITS);
         cubeItem.setTitle(new LocalizedText("Cube Item"));
         cubeItem.setAxisScaleType(AxisScaleEnumeration.Linear);
 
         // Set CubeItemType specific properties
         cubeItem.setXAxisDefinition(
             new AxisInformation(
-                new EUInformation("", -1, new LocalizedText(""), new LocalizedText("mm")),
+                MILLIMETRE_UNITS,
                 new Range(0.0, 10.0),
                 new LocalizedText("X Axis"),
                 AxisScaleEnumeration.Linear,
                 new Double[] {0.0, 10.0}));
         cubeItem.setYAxisDefinition(
             new AxisInformation(
-                new EUInformation("", -1, new LocalizedText(""), new LocalizedText("mm")),
+                MILLIMETRE_UNITS,
                 new Range(0.0, 10.0),
                 new LocalizedText("Y Axis"),
                 AxisScaleEnumeration.Linear,
                 new Double[] {0.0, 10.0}));
         cubeItem.setZAxisDefinition(
             new AxisInformation(
-                new EUInformation("", -1, new LocalizedText(""), new LocalizedText("mm")),
+                MILLIMETRE_UNITS,
                 new Range(0.0, 10.0),
                 new LocalizedText("Z Axis"),
                 AxisScaleEnumeration.Linear,
@@ -371,22 +374,21 @@ public class DataAccessProfileFragment extends ManagedAddressSpaceFragmentWithLi
         // Set ArrayItemType properties
         imageItem.setInstrumentRange(new Range(0.0, 100.0));
         imageItem.setEuRange(new Range(0.0, 100.0));
-        imageItem.setEngineeringUnits(
-            new EUInformation("", -1, new LocalizedText(""), new LocalizedText("units")));
+        imageItem.setEngineeringUnits(DIMENSIONLESS_UNITS);
         imageItem.setTitle(new LocalizedText("Image Item"));
         imageItem.setAxisScaleType(AxisScaleEnumeration.Linear);
 
         // Set ImageItemType specific properties
         imageItem.setXAxisDefinition(
             new AxisInformation(
-                new EUInformation("", -1, new LocalizedText(""), new LocalizedText("pixels")),
+                DIMENSIONLESS_UNITS,
                 new Range(0.0, 2.0),
                 new LocalizedText("X Axis"),
                 AxisScaleEnumeration.Linear,
                 new Double[] {0.0, 1.0, 2.0}));
         imageItem.setYAxisDefinition(
             new AxisInformation(
-                new EUInformation("", -1, new LocalizedText(""), new LocalizedText("pixels")),
+                DIMENSIONLESS_UNITS,
                 new Range(0.0, 2.0),
                 new LocalizedText("Y Axis"),
                 AxisScaleEnumeration.Linear,
@@ -433,8 +435,7 @@ public class DataAccessProfileFragment extends ManagedAddressSpaceFragmentWithLi
         // Set ArrayItemType properties
         nDimensionArrayItem.setInstrumentRange(new Range(0.0, 100.0));
         nDimensionArrayItem.setEuRange(new Range(0.0, 100.0));
-        nDimensionArrayItem.setEngineeringUnits(
-            new EUInformation("", -1, new LocalizedText(""), new LocalizedText("units")));
+        nDimensionArrayItem.setEngineeringUnits(DIMENSIONLESS_UNITS);
         nDimensionArrayItem.setTitle(new LocalizedText("NDimensionArray Item"));
         nDimensionArrayItem.setAxisScaleType(AxisScaleEnumeration.Linear);
 
@@ -442,14 +443,14 @@ public class DataAccessProfileFragment extends ManagedAddressSpaceFragmentWithLi
         AxisInformation[] axisDefinitions = new AxisInformation[2];
         axisDefinitions[0] =
             new AxisInformation(
-                new EUInformation("", -1, new LocalizedText(""), new LocalizedText("units")),
+                DIMENSIONLESS_UNITS,
                 new Range(0.0, 1.0),
                 new LocalizedText("Axis 0"),
                 AxisScaleEnumeration.Linear,
                 new Double[] {0.0, 1.0});
         axisDefinitions[1] =
             new AxisInformation(
-                new EUInformation("", -1, new LocalizedText(""), new LocalizedText("units")),
+                DIMENSIONLESS_UNITS,
                 new Range(0.0, 2.0),
                 new LocalizedText("Axis 1"),
                 AxisScaleEnumeration.Linear,
@@ -492,15 +493,14 @@ public class DataAccessProfileFragment extends ManagedAddressSpaceFragmentWithLi
         // Set ArrayItemType properties
         xyArrayItem.setInstrumentRange(new Range(0.0, 100.0));
         xyArrayItem.setEuRange(new Range(0.0, 100.0));
-        xyArrayItem.setEngineeringUnits(
-            new EUInformation("", -1, new LocalizedText(""), new LocalizedText("units")));
+        xyArrayItem.setEngineeringUnits(DIMENSIONLESS_UNITS);
         xyArrayItem.setTitle(new LocalizedText("XYArray Item"));
         xyArrayItem.setAxisScaleType(AxisScaleEnumeration.Linear);
 
         // Set XYArrayItemType specific properties
         xyArrayItem.setXAxisDefinition(
             new AxisInformation(
-                new EUInformation("", -1, new LocalizedText(""), new LocalizedText("units")),
+                DIMENSIONLESS_UNITS,
                 new Range(0.0, 5.0),
                 new LocalizedText("X Axis"),
                 AxisScaleEnumeration.Linear,
@@ -542,15 +542,14 @@ public class DataAccessProfileFragment extends ManagedAddressSpaceFragmentWithLi
         // Set ArrayItemType properties
         yArrayItem.setInstrumentRange(new Range(0.0, 100.0));
         yArrayItem.setEuRange(new Range(0.0, 100.0));
-        yArrayItem.setEngineeringUnits(
-            new EUInformation("", -1, new LocalizedText(""), new LocalizedText("units")));
+        yArrayItem.setEngineeringUnits(DIMENSIONLESS_UNITS);
         yArrayItem.setTitle(new LocalizedText("YArray Item"));
         yArrayItem.setAxisScaleType(AxisScaleEnumeration.Linear);
 
         // Set YArrayItemType specific properties
         yArrayItem.setXAxisDefinition(
             new AxisInformation(
-                new EUInformation("", -1, new LocalizedText(""), new LocalizedText("units")),
+                DIMENSIONLESS_UNITS,
                 new Range(0.0, 5.0),
                 new LocalizedText("X Axis"),
                 AxisScaleEnumeration.Linear,

--- a/src/test/java/com/digitalpetri/opcua/server/namespace/demo/ctt/CttNodesIT.java
+++ b/src/test/java/com/digitalpetri/opcua/server/namespace/demo/ctt/CttNodesIT.java
@@ -14,9 +14,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
+import org.eclipse.milo.opcua.sdk.core.CefactEngineeringUnits;
 import org.eclipse.milo.opcua.stack.core.NodeIds;
 import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ExtensionObject;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.BrowseDirection;
@@ -28,6 +31,7 @@ import org.eclipse.milo.opcua.stack.core.types.structured.BrowseResult;
 import org.eclipse.milo.opcua.stack.core.types.structured.CallMethodRequest;
 import org.eclipse.milo.opcua.stack.core.types.structured.CallMethodResult;
 import org.eclipse.milo.opcua.stack.core.types.structured.CallResponse;
+import org.eclipse.milo.opcua.stack.core.types.structured.EUInformation;
 import org.eclipse.milo.opcua.stack.core.types.structured.ReferenceDescription;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -193,6 +197,38 @@ class CttNodesIT {
     assertNotNull(value, "Value should be readable");
     assertNotNull(value.getValue(), "Value should not be null");
     logger.info("Read DoubleAnalog value: {}", value.getValue().getValue());
+  }
+
+  @Test
+  void testDataAccessProfileArrayItemEngineeringUnitsUseOfficialDefinitions() throws Exception {
+    List<NodeId> engineeringUnitsNodeIds =
+        List.of(
+            new NodeId(2, "CTT.Static.DataAccessProfile.ArrayItemType.CubeItem/0:EngineeringUnits"),
+            new NodeId(
+                2, "CTT.Static.DataAccessProfile.ArrayItemType.ImageItem/0:EngineeringUnits"),
+            new NodeId(
+                2,
+                "CTT.Static.DataAccessProfile.ArrayItemType.NDimensionArrayItem/0:"
+                    + "EngineeringUnits"),
+            new NodeId(
+                2, "CTT.Static.DataAccessProfile.ArrayItemType.XYArrayItem/0:EngineeringUnits"),
+            new NodeId(
+                2, "CTT.Static.DataAccessProfile.ArrayItemType.YArrayItem/0:EngineeringUnits"));
+
+    for (NodeId engineeringUnitsNodeId : engineeringUnitsNodeIds) {
+      DataValue value = client.readValue(0.0, TimestampsToReturn.Neither, engineeringUnitsNodeId);
+
+      assertNotNull(value, "EngineeringUnits value should be readable: " + engineeringUnitsNodeId);
+      assertTrue(
+          value.getStatusCode().isGood(),
+          "EngineeringUnits read should succeed for "
+              + engineeringUnitsNodeId
+              + ": "
+              + value.getStatusCode());
+
+      EUInformation engineeringUnits = decodeEngineeringUnits(value, engineeringUnitsNodeId);
+      assertOfficialEngineeringUnits(engineeringUnits, engineeringUnitsNodeId);
+    }
   }
 
   @Test
@@ -446,5 +482,55 @@ class CttNodesIT {
     }
 
     return null;
+  }
+
+  private EUInformation decodeEngineeringUnits(DataValue value, NodeId nodeId) throws Exception {
+    assertNotNull(value.getValue(), "EngineeringUnits variant should be present: " + nodeId);
+
+    Object valueObject = value.getValue().getValue();
+    if (valueObject instanceof EUInformation engineeringUnits) {
+      return engineeringUnits;
+    }
+
+    if (valueObject instanceof ExtensionObject extensionObject) {
+      Object decoded = extensionObject.decode(client.getStaticEncodingContext());
+      if (decoded instanceof EUInformation engineeringUnits) {
+        return engineeringUnits;
+      }
+    }
+
+    fail("EngineeringUnits should decode to EUInformation for " + nodeId + ", got: " + valueObject);
+    return null;
+  }
+
+  private void assertOfficialEngineeringUnits(EUInformation engineeringUnits, NodeId nodeId) {
+    String namespaceUri = engineeringUnits.getNamespaceUri();
+    assertNotNull(namespaceUri, "EngineeringUnits namespace URI should be present: " + nodeId);
+    assertFalse(
+        namespaceUri.isBlank(), "EngineeringUnits namespace URI should not be blank: " + nodeId);
+
+    Integer unitId = engineeringUnits.getUnitId();
+    assertNotNull(unitId, "EngineeringUnits unit ID should be present: " + nodeId);
+    assertTrue(unitId >= 0, "EngineeringUnits unit ID should be non-negative: " + nodeId);
+
+    EUInformation officialDefinition = CefactEngineeringUnits.getByUnitId(unitId);
+    assertNotNull(
+        officialDefinition,
+        "EngineeringUnits unit ID should resolve to a CEFACT definition: " + nodeId);
+    assertEquals(
+        officialDefinition.getNamespaceUri(),
+        namespaceUri,
+        "EngineeringUnits should use the official CEFACT namespace URI: " + nodeId);
+    assertLocalizedTextPresent(engineeringUnits.getDisplayName(), "display name", nodeId);
+    assertLocalizedTextPresent(engineeringUnits.getDescription(), "description", nodeId);
+  }
+
+  private void assertLocalizedTextPresent(LocalizedText text, String label, NodeId nodeId) {
+    assertNotNull(text, "EngineeringUnits " + label + " should be present: " + nodeId);
+    assertNotNull(
+        text.getText(), "EngineeringUnits " + label + " text should be present: " + nodeId);
+    assertFalse(
+        text.getText().isBlank(),
+        "EngineeringUnits " + label + " text should not be blank: " + nodeId);
   }
 }


### PR DESCRIPTION
## Summary

Replaces the CTT ArrayItem placeholder `EngineeringUnits` values with official CEFACT `EUInformation` definitions so the demo fixtures no longer expose empty namespace URIs or `-1` unit IDs.

- Uses Milo's `CefactEngineeringUnits` constants for the five CTT-reported ArrayItem `EngineeringUnits` properties.
- Updates nearby ArrayItem axis definitions to use official dimensionless or millimetre units instead of placeholder EUInformation values.
- Adds focused integration coverage for the exact five CTT-reported `EngineeringUnits` property nodes.

## Key Changes

- **ArrayItem units:** The generic array fixture values now use CEFACT `CODE_C62` (`one`) as a dimensionless unit, while cube spatial axes use CEFACT `CODE_MMT` (`millimetre`). This keeps the demo data semantically neutral while satisfying official UN/CEFACT unit metadata requirements.
- **CTT coverage:** `CttNodesIT` reads each affected `.../0:EngineeringUnits` property node and verifies that the decoded `EUInformation` has a non-empty namespace URI, a non-negative unit ID, and resolves through `CefactEngineeringUnits.getByUnitId(...)`.

## Testing

- `CttNodesIT` covers the five CTT-reported ArrayItem `EngineeringUnits` property nodes.
- `mise exec -- mvn -q -Dit.test=CttNodesIT verify`
